### PR TITLE
fix: remove url from pyproject.toml

### DIFF
--- a/{{cookiecutter.project_slug}}/pyproject.toml
+++ b/{{cookiecutter.project_slug}}/pyproject.toml
@@ -9,7 +9,6 @@
 
 [project]
 name = "{{ cookiecutter.project_slug }}"
-url = "https://github.com/{{ cookiecutter.github_username }}/{{ cookiecutter.project_slug }}"
 authors = [
     {name="{{ cookiecutter.full_name.replace('\"', '\\\"') }}", email="{{ cookiecutter.email }}"}
 ]


### PR DESCRIPTION
pyproject.toml doesn't support having a url entry in metadata. Remove it.